### PR TITLE
Use published latest build123d from pypi    

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,7 +85,7 @@ jobs:
         run: docker save  ${{ steps.meta.outputs.tags }} -o image.tar  # Export image as tar file
 
       - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: image
           path: image.tar  # Path to the exported Docker image tar file

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -81,15 +81,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Save Docker image to tar file
-        run: docker save  ${{ steps.meta.outputs.tags }} -o image.tar  # Export image as tar file
-
-      - name: Upload Docker image artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: image
-          path: image.tar  # Path to the exported Docker image tar file
-
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker
       # repository is public to avoid leaking data.  If you would like to publish

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -81,6 +81,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Save Docker image to tar file
+        run: docker save  ${{ steps.meta.outputs.tags }} -o image.tar  # Export image as tar file
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: image
+          path: image.tar  # Path to the exported Docker image tar file
+
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker
       # repository is public to avoid leaking data.  If you would like to publish

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM registry.fedoraproject.org/fedora-minimal:latest
-ADD ./install_vsix.sh /install_vsix.sh
 ADD ./install-cadquery.sh /install-cadquery.sh
 RUN bash /install-cadquery.sh
 ADD ./entrypoint.sh /entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3"
 services:
   build123d:
     image: ghcr.io/ankurvdev/vscode-build123d:main
-    restart: unless-stopped
     ports:
       - 5000:8080
     volumes:

--- a/install-cadquery.sh
+++ b/install-cadquery.sh
@@ -24,8 +24,8 @@ python3 -m pip install --root-user-action=ignore --upgrade git+https://github.co
 
 curl -fsSL https://code-server.dev/install.sh | sh
 
-install_vsix.sh "ms-python" "python"
-install_vsix.sh "ms-python" "black-formatter"
-install_vsix.sh "ms-vscode" "vs-keybindings"
-install_vsix.sh "charliermarsh" "ruff"
-install_vsix.sh "bernhard-42" "ocp-cad-viewer"
+install_vsix "ms-python" "python"
+install_vsix "ms-python" "black-formatter"
+install_vsix "ms-vscode" "vs-keybindings"
+install_vsix "charliermarsh" "ruff"
+install_vsix "bernhard-42" "ocp-cad-viewer"

--- a/install-cadquery.sh
+++ b/install-cadquery.sh
@@ -4,15 +4,14 @@ set -u
 set -o pipefail
 
 microdnf -y update
-microdnf -y install curl python3-pip python3-virtualenv git libglvnd-glx python3-NLopt python3.13 python3-pip python3-virtualenv
+microdnf -y install curl git libglvnd-glx python3-pip python3-virtualenv python3-NLopt
 microdnf clean all
 
-alternatives --install /usr/bin/python python /usr/bin/python3.13 1
-python3.13 -m ensurepip
-python3.13 -m pip install --root-user-action=ignore --upgrade pip black ruff
-python3.13 -m pip install --root-user-action=ignore --upgrade ocp_vscode cadquery
-python3.13 -m pip install --root-user-action=ignore --upgrade git+https://github.com/gumyr/build123d
-python3.13 -m pip install --root-user-action=ignore --upgrade git+https://github.com/gumyr/bd_warehouse
+python3 -m ensurepip
+python3 -m pip install --root-user-action=ignore --upgrade pip black ruff
+python3 -m pip install --root-user-action=ignore --upgrade ocp_vscode cadquery
+python3 -m pip install --root-user-action=ignore --upgrade build123d
+python3 -m pip install --root-user-action=ignore --upgrade git+https://github.com/gumyr/bd_warehouse
 curl -fsSL https://code-server.dev/install.sh | sh
 
 bash /install_vsix.sh "ms-python" "python"

--- a/install-cadquery.sh
+++ b/install-cadquery.sh
@@ -3,19 +3,29 @@ set -e
 set -u
 set -o pipefail
 
+install_vsix() {
+  publisher=$1
+  name=$2
+  version=$(curl -s -c cookies.txt "https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}" | grep -o 'VersionValue":"\([^"]*\)' | cut -c 16-)
+  echo "Installing $1.$2:$version"
+  curl -s --compressed -j -b cookies.txt -o ${publisher}.${name}.vsix  https://marketplace.visualstudio.com/_apis/public/gallery/publishers/${publisher}/vsextensions/${name}/${version}/vspackage
+  /usr/bin/code-server --install-extension ${publisher}.${name}.vsix
+  rm ${publisher}.${name}.vsix
+}
+
 microdnf -y update
 microdnf -y install curl git libglvnd-glx python3-pip python3-virtualenv python3-NLopt
 microdnf clean all
 
 python3 -m ensurepip
-python3 -m pip install --root-user-action=ignore --upgrade pip black ruff
-python3 -m pip install --root-user-action=ignore --upgrade ocp_vscode cadquery
-python3 -m pip install --root-user-action=ignore --upgrade build123d
+python3 -m pip install --root-user-action=ignore --upgrade pip
+python3 -m pip install --root-user-action=ignore --upgrade black ruff ocp_vscode cadquery build123d
 python3 -m pip install --root-user-action=ignore --upgrade git+https://github.com/gumyr/bd_warehouse
+
 curl -fsSL https://code-server.dev/install.sh | sh
 
-bash /install_vsix.sh "ms-python" "python"
-bash /install_vsix.sh "ms-python" "black-formatter"
-bash /install_vsix.sh "ms-vscode" "vs-keybindings"
-bash /install_vsix.sh "charliermarsh" "ruff"
-bash /install_vsix.sh "bernhard-42" "ocp-cad-viewer"
+install_vsix.sh "ms-python" "python"
+install_vsix.sh "ms-python" "black-formatter"
+install_vsix.sh "ms-vscode" "vs-keybindings"
+install_vsix.sh "charliermarsh" "ruff"
+install_vsix.sh "bernhard-42" "ocp-cad-viewer"

--- a/install_vsix.sh
+++ b/install_vsix.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-publisher=$1
-name=$2
-version=$(curl -s -c cookies.txt "https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}" | grep -o 'VersionValue":"\([^"]*\)' | cut -c 16-)
-echo "Installing $1.$2:$version"
-curl -s --compressed -j -b cookies.txt -o ${publisher}.${name}.vsix  https://marketplace.visualstudio.com/_apis/public/gallery/publishers/${publisher}/vsextensions/${name}/${version}/vspackage
-/usr/bin/code-server --install-extension ${publisher}.${name}.vsix
-rm ${publisher}.${name}.vsix


### PR DESCRIPTION
* Update pip before other packages are installed
* Simplify and consolidate install scripts
* Use build123d from pypi